### PR TITLE
Add a drawsAsync property to the text view

### DIFF
--- a/Source/StyledTextRenderer.swift
+++ b/Source/StyledTextRenderer.swift
@@ -96,6 +96,14 @@ public final class StyledTextRenderer {
         clearOnWarning: true
     )
 
+    public func cachedRender(for width: CGFloat) -> (image: CGImage?, size: CGSize?) {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+
+        let key = StyledTextRenderCacheKey(width: width, attributedText: storage, backgroundColor: backgroundColor)
+        return (StyledTextRenderer.globalBitmapCache[key], StyledTextRenderer.globalSizeCache[key])
+    }
+
     public func render(for width: CGFloat) -> (image: CGImage?, size: CGSize) {
         os_unfair_lock_lock(&lock)
         defer { os_unfair_lock_unlock(&lock) }

--- a/Source/StyledTextView.swift
+++ b/Source/StyledTextView.swift
@@ -163,11 +163,16 @@ open class StyledTextView: UIView {
     }
 
     private func setRenderResults(renderer: StyledTextRenderer, result: (CGImage?, CGSize)) {
-        self.layer.contents = result.0
-        self.frame = CGRect(origin: CGPoint(x: renderer.inset.left, y: renderer.inset.top), size: result.1)
+        layer.contents = result.0
+        frame = CGRect(origin: CGPoint(x: renderer.inset.left, y: renderer.inset.top), size: result.1)
     }
 
-    static var renderQueue = DispatchQueue(label: "com.whoisryannystrom.StyledText.renderQueue", qos: .default, attributes: DispatchQueue.Attributes(rawValue: 0), autoreleaseFrequency: .workItem, target: nil)
+    static var renderQueue = DispatchQueue(
+      label: "com.whoisryannystrom.StyledText.renderQueue",
+      qos: .default, attributes: DispatchQueue.Attributes(rawValue: 0),
+      autoreleaseFrequency: .workItem, 
+      target: nil
+    )
 
     // MARK: Public API
 


### PR DESCRIPTION
This is my first pass at a threadsafe async drawing system.

Problems to resolve before merge:

1. If the bitmap is cached, there's no purpose to this, it should short-circuit instead of trampolining.
2. The logic inside this function feels a little icky. We should clean it up a little bit.

Known problems:
1. Testing, as with all async modes, is nearly impossible.