### PR TITLE
Basic three-rect selection

### DIFF
--- a/Source/StyledTextView.swift
+++ b/Source/StyledTextView.swift
@@ -144,13 +144,37 @@ open class StyledTextView: UIView {
 
         let range = NSRange(location: min, length: max - min)
 
+        var firstRect: CGRect = CGRect.null
+        var bodyRect: CGRect = CGRect.null
+        var lastRect: CGRect = CGRect.null
+
         let path = UIBezierPath()
+
         renderer.layoutManager.enumerateEnclosingRects(
             forGlyphRange: range,
             withinSelectedGlyphRange: NSRange(location: NSNotFound, length: 0),
             in: renderer.textContainer
         ) { (rect, stop) in
-            path.append(UIBezierPath(roundedRect: rect.insetBy(dx: -2, dy: -2), cornerRadius: 3))
+            if firstRect.isNull {
+                firstRect = rect
+            } else if lastRect.isNull {
+                lastRect = rect
+            } else {
+                // We have a lastRect that was previously filled, now it needs to be dumped into the body
+                bodyRect = lastRect.intersection(bodyRect)
+                // and save the current rect as the new "lastRect"
+                lastRect = rect
+            }
+        }
+
+        if !firstRect.isNull {
+            path.append(UIBezierPath(roundedRect: firstRect.insetBy(dx: -2, dy: -2), cornerRadius: 3))
+        }
+        if !bodyRect.isNull {
+            path.append(UIBezierPath(roundedRect: bodyRect.insetBy(dx: -2, dy: -2), cornerRadius: 3))
+        }
+        if !lastRect.isNull {
+            path.append(UIBezierPath(roundedRect: lastRect.insetBy(dx: -2, dy: -2), cornerRadius: 3))
         }
 
         highlightLayer.frame = bounds


### PR DESCRIPTION
This is a really basic implementation of the three-rect selection system that most major browsers and OSes implement.

However, it isn't fully-featured:

1. In most other algorithms the bottom of the firstRect will be extended downward to intersect with the bodyRect. Same with the lastRect, but upwards. This is pretty easy to implement, but I just haven't done it here.
2. In most other algorithms the firstRect's right boundary is aligned with the right bounds of the body, and similarly for the lastRect aligned with the left boundary of the body. This is ugly to implement because the logic has to be flipped for RTL layouts.

Resolves most of https://github.com/GitHawkApp/StyledTextKit/issues/27