### PR TITLE
Revert "Overrode Intrinsic Content Size "

### DIFF
--- a/Source/StyledTextView.swift
+++ b/Source/StyledTextView.swift
@@ -24,14 +24,6 @@ open class StyledTextView: UIView {
     private var longPressGesture: UILongPressGestureRecognizer?
     private var highlightLayer = CAShapeLayer()
 
-    open override var intrinsicContentSize: CGSize {
-        if let renderer = renderer {
-            return renderer.viewSize(in: bounds.width)
-        } else {
-            return bounds.size
-        }
-    }
-    
     override public init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
@@ -197,7 +189,6 @@ open class StyledTextView: UIView {
     private func setRenderResults(renderer: StyledTextRenderer, result: (CGImage?, CGSize)) {
         layer.contents = result.0
         frame = CGRect(origin: CGPoint(x: renderer.inset.left, y: renderer.inset.top), size: result.1)
-        invalidateIntrinsicContentSize()
     }
 
     static var renderQueue = DispatchQueue(


### PR DESCRIPTION
Reverts GitHawkApp/StyledTextKit#42

FYI this caused a ton of layout issues within GitHawk. Probably need to add some snapshot tests on the actual `StyledTextView`.