### PR TITLE
Support minimum deployment target from 10.0 to 9.0 when install using Cocoapods  

### DIFF
--- a/StyledTextKit.podspec
+++ b/StyledTextKit.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |spec|
   spec.summary      = 'Declarative building and fast rendering attributed string library.'
   spec.source       = { :git => 'https://github.com/GitHawkApp/StyledTextKit/StyledTextKit.git', :tag => spec.version.to_s }
   spec.source_files = 'Source/*.swift'
-  spec.platform     = :ios, '10.0'
+  spec.platform     = :ios, '9.0'
   spec.swift_version = '4.0'
 end


### PR DESCRIPTION
Fix #53 