### PR TITLE
fix TextStyle font's preferredSize to respect given min and max size

### DIFF
--- a/Source/TextStyle.swift
+++ b/Source/TextStyle.swift
@@ -37,7 +37,7 @@ public struct TextStyle: Hashable, Equatable {
     }
 
     public func font(contentSizeCategory: UIContentSizeCategory) -> UIFont {
-        let preferredSize = contentSizeCategory.preferredContentSize(size)
+        let preferredSize = contentSizeCategory.preferredContentSize(size, minSize: minSize, maxSize: maxSize)
 
         switch font {
         case .name(let name):


### PR DESCRIPTION
TextStyle doesn't respect its own min and max size, noticed it's not actually applied anywhere. These seemed to be missing.